### PR TITLE
Sets the correct offset when there is only one child

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,13 @@ var Carousel = React.createClass({
       this._setUpTimer();
     }
   },
+  componentWillReceiveProps: function(nextProps) {
+    if (nextProps.children.length === 1) {
+      this.setState({
+        contentOffset: { x: 0 },
+      });
+    }
+  },
   _onScrollBegin: function(event) {
     this.clearTimeout(this.timer);
   },


### PR DESCRIPTION
I was experiencing a bug with the offset where the only child in the carousel doesn't show. This is because the offset is still set when there's no leading or trailing view since it's the only child. So far, componentWillReceiveProps is the best place I've found in the React lifecycle to do a check of the number of children and changing the contentOffset state. But feel free to change it if you find a better place!