### PR TITLE
update scrollTo api to newer

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ var Carousel = React.createClass({
         this.props.onAnimateNextPage(this.state.currentPage)
       }
     })
-    this.refs.scrollView.scrollTo(0, k*size.width);
+    this.refs.scrollView.scrollTo({x: k*size.width, y: 0});
     this._setUpTimer();
   },
   _calculateCurrentPage(offset) {


### PR DESCRIPTION
consider react-native version `0.20.0`, old `scrollTo` api will get below warning message.

    `scrollTo(y, x, animated)` is deprecated. Use `scrollTo({x: 5, y: 5, animated: true})` instead.

change it to `this.refs.scrollView.scrollTo({x: k*size.width, y: 0});` could be solved.