### PR TITLE
Fix dragging on ios with current RN version

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,9 +241,9 @@ export default class Carousel extends Component {
     }
 
     pages = pages.map((page, i) =>
-      <View style={[{ ...size }, this.props.pageStyle]} key={`page${i}`}>
+      <TouchableWithoutFeedback style={[{ ...size }, this.props.pageStyle]} key={`page${i}`}>
         {page}
-      </View>
+      </TouchableWithoutFeedback>
     );
 
     const containerProps = {


### PR DESCRIPTION
Hi!

In the current ReactNative version dragging inside the `ScrollView` stopped working on iOS.
I could fix it by wrapping the slides into `TouchableWithoutFeedback`.

See: http://stackoverflow.com/questions/39833003/react-native-scrollview-is-not-working-in-ios