### PR TITLE
Allow Elements in arrow texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ chosenBulletStyle | stlye | null | style for the selected bullet
 arrows | bool | false | wether to show navigation arrows for the carousel
 arrowsStyle | style | null | style for navigation arrows
 arrowsContainerStyle | style | null | style for the navigation arrows container
-leftArrowText | string | 'Left' | label for left navigation arrow
-rightArrowText | string | 'Right' | label for right navigation arrow
+leftArrowText | string / element | 'Left' | label / icon for left navigation arrow
+rightArrowText | string / element | 'Right' | label / icon for right navigation arrow
 
 ## Usage
 ```js

--- a/index.js
+++ b/index.js
@@ -34,8 +34,14 @@ export default class Carousel extends Component {
     arrows: React.PropTypes.bool,
     arrowsContainerStyle: Text.propTypes.style,
     arrowstyle: Text.propTypes.style,
-    leftArrowText: React.PropTypes.string,
-    rightArrowText: React.PropTypes.string,
+    leftArrowText: React.propTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.element,
+    ]),
+    rightArrowText: React.propTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.element,
+    ]),
     chosenBulletStyle: Text.propTypes.style,
     onAnimateNextPage: React.PropTypes.func,
   };


### PR DESCRIPTION
Hello!

This PR, allows the use of React elements inside of `arrowLeftText` and `arrowRightText` props. Allowing the use of navigation icons for the Carousel.

Example: 

```language-javascript
import MaterialIcon from 'react-native-vector-icons/MaterialIcons'

<Carousel 
  arrows 
  leftArrowText={<MaterialIcon name={'keyboard-arrow-left'} />}
  rightArrowText={<MaterialIcon name={'keyboard-arrow-right'} />} >
</Carousel>
```