### PR TITLE
Optimization Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.6
+- Fix issue with carousel toScroll not working properly on Android
+- Performance optimizations
+
 ## 0.1.3
 
 - Fixed issue with `currentPage` property not working properly

--- a/index.js
+++ b/index.js
@@ -34,11 +34,11 @@ export default class Carousel extends Component {
     arrows: React.PropTypes.bool,
     arrowsContainerStyle: Text.propTypes.style,
     arrowstyle: Text.propTypes.style,
-    leftArrowText: React.propTypes.oneOfType([
+    leftArrowText: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.element,
     ]),
-    rightArrowText: React.propTypes.oneOfType([
+    rightArrowText: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.element,
     ]),

--- a/index.js
+++ b/index.js
@@ -148,6 +148,11 @@ export default class Carousel extends Component {
   _scrollTo = (offset, animated) => {
     if (this.scrollView) {
       this.scrollView.scrollTo({ y: 0, x: offset, animated });
+
+      // Fix bug #50
+      if (Platform.OS === 'android' && !animated) {
+        this.scrollView.scrollTo({ y: 0, x: offset, animated: true });
+      }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-looped-carousel",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Looped carousel for React Native",
   "author": "Phil Rukin <philipp@rukin.me> (http://rukin.me)",
   "contributors": [


### PR DESCRIPTION
- `React.propTypes` throws an error for me. I updated to `React.PropTypes`
-  I updated bug #50 to only kick in when on Android and if not already animating
-  Other updates are for optimization of the loading of the carousel which prevents `render()` from being called as many times and use Promises for constructing the pages and carousel view content. This is particularly helpful when using several carousels in the same view.
- Uses `React.Children` where appropriate as the `children` property is opaque and no assumptions should be made such as assuming it'll be an array.