### PR TITLE
Add ability to slide carousel from parent component

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,18 @@ pageInfoBackgroundColor | string | 'rgba(0, 0, 0, 0.25)' | background color for 
 pageInfoTextStyle | style | null | style for text in pageInfo
 pageInfoTextSeparator | string | ' / ' | separator for `{currentPage}` and `{totalNumberOfPages}`
 |
-bullets | bool | false | wether to show "bullets" at the bottom of the carousel
+bullets | bool | false | whether to show "bullets" at the bottom of the carousel
 bulletStyle | style | null | style for each bullet
 bulletsContainerStyle | style | null | style for the bullets container
 chosenBulletStyle | stlye | null | style for the selected bullet
 |
-arrows | bool | false | wether to show navigation arrows for the carousel
+arrows | bool | false | whether to show navigation arrows for the carousel
 arrowsStyle | style | null | style for navigation arrows
 arrowsContainerStyle | style | null | style for the navigation arrows container
 leftArrowText | string / element | 'Left' | label / icon for left navigation arrow
 rightArrowText | string / element | 'Right' | label / icon for right navigation arrow
+animateTo | number | 0 | slide carousel to this page, needs to be activated with `refreshAnimation`
+refreshAnimation | number | 0 | carousel slides to `animateTo` page every time this value changes to a new non-zero number
 
 ## Usage
 ```js

--- a/index.js
+++ b/index.js
@@ -105,7 +105,8 @@ export default class Carousel extends Component {
     }
     this.setState({ childrenLength });
     this._setUpTimer();
-    if (nextProps.refreshAnimation !== 0) {
+    if (nextProps.refreshAnimation && nextProps.refreshAnimation !== 0 && this.state.refreshAnimation !== nextProps.refreshAnimation) {
+      this.setState({refreshAnimation: nextProps.refreshAnimation})
       this.setState({currentPage: nextProps.animateTo});
       this._animateToPage(nextProps.animateTo);
     }

--- a/index.js
+++ b/index.js
@@ -44,6 +44,8 @@ export default class Carousel extends Component {
     ]),
     chosenBulletStyle: Text.propTypes.style,
     onAnimateNextPage: React.PropTypes.func,
+    animateTo: React.PropTypes.number,
+    refreshAnimation: React.PropTypes.number,
   };
 
   static defaultProps = {
@@ -67,6 +69,8 @@ export default class Carousel extends Component {
     leftArrowText: '',
     rightArrowText: '',
     onAnimateNextPage: undefined,
+    animateTo: 0,
+    refreshAnimation: 0,
   };
 
   constructor(props) {
@@ -101,6 +105,10 @@ export default class Carousel extends Component {
     }
     this.setState({ childrenLength });
     this._setUpTimer();
+    if (nextProps.refreshAnimation !== 0) {
+      this.setState({currentPage: nextProps.animateTo});
+      this._animateToPage(nextProps.animateTo);
+    }
   }
 
   _onScrollBegin = () => {


### PR DESCRIPTION
Hi everyone!

We wanted to be able to slide the carousel to *n*-th page with a press of a button. Maybe it might be useful for others as well.

You can pass the page you want the carousel to slide to as `animateTo`. Then, every time you want the carousel to slide send a new non-zero number as `refreshAnimation` (the easiest way to do this is to increment it in parent).