### PR TITLE
Fix improper PropTypes declaration [showstopper]

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,11 +34,11 @@ export default class Carousel extends Component {
     arrows: React.PropTypes.bool,
     arrowsContainerStyle: Text.propTypes.style,
     arrowstyle: Text.propTypes.style,
-    leftArrowText: React.propTypes.oneOfType([
+    leftArrowText: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.element,
     ]),
-    rightArrowText: React.propTypes.oneOfType([
+    rightArrowText: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.element,
     ]),


### PR DESCRIPTION
Arrow texts referred to `React.propTypes` instead of `React.PropTypes` resulting in a crashing build (on master). This issue was introduced in https://github.com/appintheair/react-native-looped-carousel/commit/8b31d50c944d0d0e41abb104d718f5213e06dc45.

This patch fixes it.