### PR TITLE
Expose currentPage

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,6 +103,10 @@ export default class Carousel extends Component {
     this._setUpTimer();
   }
 
+  getCurrentPage() {
+    return this.state.currentPage;
+  }
+
   _onScrollBegin = () => {
     this._clearTimer();
   }


### PR DESCRIPTION
Exposes the internal `currentPage`. This can prove useful when one needs to manipulate other components based on the carousel page.

In our case we need to sync two carousels with each other (one being in a modal). To do so, we need access to `currentPage`.