### PR TITLE
Bugfixes for rendering, swiping and animation.

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,12 +190,12 @@ export default class Carousel extends Component {
     }
   }
 
-  _scrollTo = (offset, animated) => {
+  _scrollTo = ({ offset, animated, nofix }) => {
     if (this.scrollView) {
       this.scrollView.scrollTo({ y: 0, x: offset, animated });
 
       // Fix bug #50
-      if (Platform.OS === 'android' && !animated) {
+      if (!nofix && Platform.OS === 'android' && !animated) {
         this.scrollView.scrollTo({ y: 0, x: offset, animated: true });
       }
     }
@@ -215,13 +215,20 @@ export default class Carousel extends Component {
       currentPage = 0;
     }
     if (currentPage === 0) {
-      this._scrollTo((childrenLength - 1) * width, false);
-      this._scrollTo(childrenLength * width, true);
+      // animate properly based on direction
+      const scrollMultiplier = this.state.currentPage === 1 ? 1 : -1;
+      this._scrollTo({
+        offset: (childrenLength + (1 * scrollMultiplier)) * width,
+        animated: false,
+        nofix: true,
+      });
+      this._scrollTo({ offset: childrenLength * width, animated: true });
     } else if (currentPage === 1) {
-      this._scrollTo(0, false);
-      this._scrollTo(width, true);
+      const scrollMultiplier = this.state.currentPage === 0 ? 0 : 2;
+      this._scrollTo({ offset: width * scrollMultiplier, animated: false, nofix: true });
+      this._scrollTo({ offset: width, animated: true });
     } else {
-      this._scrollTo(currentPage * width, true);
+      this._scrollTo({ offset: currentPage * width, animated: true });
     }
     this._setCurrentPage(currentPage);
     this._setUpTimer();
@@ -231,13 +238,13 @@ export default class Carousel extends Component {
     const { childrenLength } = this.state;
     const { width } = this.state.size;
     if (childrenLength === 1) {
-      this._scrollTo(0, false);
+      this._scrollTo({ offset: 0, animated: false });
     } else if (page === 0) {
-      this._scrollTo(childrenLength * width, false);
+      this._scrollTo({ offset: childrenLength * width, animated: false });
     } else if (page === 1) {
-      this._scrollTo(width, false);
+      this._scrollTo({ offset: width, animated: false });
     } else {
-      this._scrollTo(page * width, false);
+      this._scrollTo({ offset: page * width, animated: false });
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -307,8 +307,8 @@ export default class Carousel extends Component {
       currentPage = childrenLength;
     }
     return (
-      <View style={styles.arrows}>
-        <View style={[styles.arrowsContainer, this.props.arrowsContainerStyle]}>
+      <View style={styles.arrows} pointerEvents="box-none">
+        <View style={[styles.arrowsContainer, this.props.arrowsContainerStyle]} pointerEvents="box-none">
           <TouchableOpacity onPress={() => this.animateToPage(this._normalizePageNumber(currentPage - 1))} style={this.props.arrowstyle}><Text>{this.props.leftArrowText ? this.props.leftArrowText : 'Left'}</Text></TouchableOpacity>
           <TouchableOpacity onPress={() => this.animateToPage(this._normalizePageNumber(currentPage + 1))} style={this.props.arrowstyle}><Text>{this.props.rightArrowText ? this.props.rightArrowText : 'Right'}</Text></TouchableOpacity>
         </View>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-looped-carousel",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Looped carousel for React Native",
   "author": "Phil Rukin <philipp@rukin.me> (http://rukin.me)",
   "contributors": [


### PR DESCRIPTION
- Carousel rendering: due to some previous optimizations in which some of the UI was "pre-rendered" outside of the `render` function, layout changes that occurred afterwards would not be included in any re-rendering. This should fix that.
- When using arrows to move the carousel, the direction of the animation was sometimes incorrect for specific edge cases. These edge cases are now handled correctly.
- Inability to swipe carousel as described in #92 has been fixed.