### PR TITLE
Fix children rerendering

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ import {
   View,
   TouchableWithoutFeedback,
 } from 'react-native';
+import { isEqual } from 'lodash';
 
 
 const PAGE_CHANGE_DELAY = 4000;
@@ -103,7 +104,7 @@ export default class Carousel extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.children !== nextProps.children) {
+    if (!isEqual(this.props.children, nextProps.children)) {
       let childrenLength = 0;
       if (nextProps.children) {
         const length = React.Children.count(nextProps.children);

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ import {
   View,
   TouchableWithoutFeedback,
 } from 'react-native';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash.isequal';
 
 
 const PAGE_CHANGE_DELAY = 4000;
@@ -106,6 +106,7 @@ export default class Carousel extends Component {
   componentWillReceiveProps(nextProps) {
     if (!isEqual(this.props.children, nextProps.children)) {
       let childrenLength = 0;
+      this.setState({ currentPage: 1 });
       if (nextProps.children) {
         const length = React.Children.count(nextProps.children);
         childrenLength = length || 1;

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "eslint-plugin-react": "^6.3.0"
   },
   "dependencies": {
-    "lodash": "^4.17.4"
+    "lodash.isequal": "^4.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^3.0.2",
     "eslint-plugin-react": "^6.3.0"
+  },
+  "dependencies": {
+    "lodash": "^4.17.4"
   }
 }


### PR DESCRIPTION
When a prop gets changed, the component re-renders all children, although it's not necessary. This behaviour (while obviously hindering performance) can lead to graphical glitches when manipulating the `currentPage`. Deep equal in `componentWillReceiveProps` fixes it.

I had to introduce a new dependency on lodash to compare the children in a simple and proper way, hope that's not a problem.