### PR TITLE
Avoid pointer events on the bullet View containers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -294,8 +294,8 @@ export default class Carousel extends Component {
         </TouchableWithoutFeedback>);
     }
     return (
-      <View style={styles.bullets}>
-        <View style={[styles.bulletsContainer, this.props.bulletsContainerStyle]}>
+      <View style={styles.bullets} pointerEvents="box-none">
+        <View style={[styles.bulletsContainer, this.props.bulletsContainerStyle]} pointerEvents="box-none">
           {bullets}
         </View>
       </View>


### PR DESCRIPTION
`pointerEvents="box-none"` is applied to the containers for the arrows elements. 

This commit adds it to the bullet containers too so that users can have more area to swipe.